### PR TITLE
docs: add MkDocs documentation site with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,11 @@ on:
     branches: [main]
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g., 1.0.0)'
+        required: true
 
 permissions:
   contents: write
@@ -32,7 +37,7 @@ jobs:
         run: uv run mkdocs build --strict
 
   deploy:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -54,9 +59,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Get version from tag
+      - name: Get version
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Deploy docs with mike
         run: |


### PR DESCRIPTION
## Summary
- Adds MkDocs documentation site with Material theme (dark/light mode toggle)
- Auto-generated API reference via mkdocstrings for Client, Models, and Exceptions
- Versioned docs via mike with version selector in header
- GitHub Actions workflow: builds on PRs, deploys on release or manual trigger

## Test plan
- [x] `uv run mkdocs build --strict` passes locally
- [x] Unit tests pass
- [ ] After merge, run workflow manually with version `1.0.0` to deploy initial docs
- [ ] Verify docs at https://mattflow.github.io/osrs-prices/

🤖 Generated with [Claude Code](https://claude.com/claude-code)