### PR TITLE
fix: set default version for docs root redirect

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,3 +71,4 @@ jobs:
       - name: Deploy docs with mike
         run: |
           uv run mike deploy --push --update-aliases ${{ steps.version.outputs.version }} latest
+          uv run mike set-default --push latest


### PR DESCRIPTION
## Summary
- Adds `mike set-default --push latest` to ensure the root URL redirects to the latest docs version

Without this, visiting https://mattflow.github.io/osrs-prices/ would 404 since all docs are under version directories (`1.0.0/`, `latest/`).

## Test plan
- [x] Manually ran `mike set-default --push latest` to fix current deployment
- [ ] Future deployments will automatically set the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)