### PR TITLE
feat: add enriched response methods joining price and mapping data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ with Client(user_agent="my-app/1.0 contact@example.com") as client:
     timeseries = client.get_timeseries(item_id=4151, timestep="1h")
 ```
 
+## Enriched Responses
+
+Combine price data with item metadata in a single call:
+
+```python
+from osrs_prices import Client
+
+with Client(user_agent="my-app/1.0") as client:
+    # Get prices with item names, limits, alch values, etc.
+    enriched = client.get_latest_with_mapping()
+    for item in enriched.items:
+        print(f"{item.name}: {item.high} gp (limit: {item.limit})")
+
+    # Or enrich an existing response
+    latest = client.get_latest()
+    enriched = client.enrich(latest)
+```
+
 ## DataFrame Support
 
 Convert any response to a pandas DataFrame (requires `pip install osrs-prices[pandas]`):
@@ -59,6 +77,11 @@ with Client(user_agent="my-app/1.0") as client:
 | `get_1h_average(timestamp=None)` | 1-hour price averages |
 | `get_timeseries(item_id, timestep)` | Historical data (timestep: "5m", "1h", "6h", "24h") |
 | `get_item_by_name(name)` | Find item by exact name |
+| `get_latest_with_mapping(item_id=None)` | Latest prices with item metadata |
+| `get_5m_average_with_mapping(timestamp=None)` | 5-minute averages with item metadata |
+| `get_1h_average_with_mapping(timestamp=None)` | 1-hour averages with item metadata |
+| `get_timeseries_with_mapping(item_id, timestep)` | Timeseries with item metadata |
+| `enrich(response)` | Add item metadata to an existing response |
 
 ### Models
 
@@ -66,6 +89,9 @@ with Client(user_agent="my-app/1.0") as client:
 - `AveragePrice` - Average prices with volumes
 - `ItemMapping` - Item metadata (name, examine, alch values, etc.)
 - `TimeseriesDataPoint` - Historical price point
+- `EnrichedLatestPrice` - Latest price combined with item metadata
+- `EnrichedAveragePrice` - Average price combined with item metadata
+- `EnrichedTimeseriesResponse` - Timeseries with item metadata attached
 
 ### Exceptions
 

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -25,3 +25,17 @@ Pydantic models for API responses.
 ::: osrs_prices.TimeseriesResponse
 
 ::: osrs_prices.Timestep
+
+## Enriched Models
+
+These models combine price data with item metadata for convenience.
+
+::: osrs_prices.EnrichedLatestPrice
+
+::: osrs_prices.EnrichedLatestResponse
+
+::: osrs_prices.EnrichedAveragePrice
+
+::: osrs_prices.EnrichedAverageResponse
+
+::: osrs_prices.EnrichedTimeseriesResponse

--- a/src/osrs_prices/__init__.py
+++ b/src/osrs_prices/__init__.py
@@ -5,6 +5,11 @@ from osrs_prices.exceptions import APIError, OSRSPricesError, RateLimitError, Va
 from osrs_prices.models import (
     AveragePrice,
     AverageResponse,
+    EnrichedAveragePrice,
+    EnrichedAverageResponse,
+    EnrichedLatestPrice,
+    EnrichedLatestResponse,
+    EnrichedTimeseriesResponse,
     ItemMapping,
     LatestPrice,
     LatestResponse,
@@ -25,6 +30,11 @@ __all__ = [
     # Models
     "AveragePrice",
     "AverageResponse",
+    "EnrichedAveragePrice",
+    "EnrichedAverageResponse",
+    "EnrichedLatestPrice",
+    "EnrichedLatestResponse",
+    "EnrichedTimeseriesResponse",
     "ItemMapping",
     "LatestPrice",
     "LatestResponse",

--- a/src/osrs_prices/endpoints/timeseries.py
+++ b/src/osrs_prices/endpoints/timeseries.py
@@ -11,9 +11,14 @@ class TimeseriesEndpoint(BaseEndpoint[TimeseriesResponse]):
 
     path = "/timeseries"
 
+    def __init__(self, http_client: Any) -> None:
+        """Initialize the endpoint."""
+        super().__init__(http_client)
+        self._current_item_id: int | None = None
+
     def _parse_response(self, data: Any) -> TimeseriesResponse:
         """Parse the API response into a TimeseriesResponse."""
-        return TimeseriesResponse.from_api(data)
+        return TimeseriesResponse.from_api(data, item_id=self._current_item_id)
 
     def fetch(self, item_id: int, timestep: Timestep) -> TimeseriesResponse:
         """Fetch historical timeseries data for an item.
@@ -25,5 +30,6 @@ class TimeseriesEndpoint(BaseEndpoint[TimeseriesResponse]):
         Returns:
             The timeseries data.
         """
+        self._current_item_id = item_id
         params = {"id": str(item_id), "timestep": timestep}
         return self._request(params)

--- a/src/osrs_prices/models/__init__.py
+++ b/src/osrs_prices/models/__init__.py
@@ -1,5 +1,12 @@
 """Pydantic models for the OSRS Prices API."""
 
+from osrs_prices.models.enriched import (
+    EnrichedAveragePrice,
+    EnrichedAverageResponse,
+    EnrichedLatestPrice,
+    EnrichedLatestResponse,
+    EnrichedTimeseriesResponse,
+)
 from osrs_prices.models.items import ItemMapping, MappingResponse
 from osrs_prices.models.prices import (
     AveragePrice,
@@ -16,6 +23,11 @@ from osrs_prices.models.timeseries import (
 __all__ = [
     "AveragePrice",
     "AverageResponse",
+    "EnrichedAveragePrice",
+    "EnrichedAverageResponse",
+    "EnrichedLatestPrice",
+    "EnrichedLatestResponse",
+    "EnrichedTimeseriesResponse",
     "ItemMapping",
     "LatestPrice",
     "LatestResponse",

--- a/src/osrs_prices/models/enriched.py
+++ b/src/osrs_prices/models/enriched.py
@@ -1,0 +1,65 @@
+"""Enriched models combining price data with item metadata."""
+
+from osrs_prices.models.base import OSRSBaseModel
+from osrs_prices.models.items import ItemMapping
+from osrs_prices.models.timeseries import TimeseriesDataPoint
+
+
+class EnrichedLatestPrice(OSRSBaseModel):
+    """Latest price combined with item metadata."""
+
+    # From ItemMapping
+    id: int
+    name: str
+    examine: str | None = None
+    members: bool
+    lowalch: int | None = None
+    highalch: int | None = None
+    limit: int | None = None
+    value: int | None = None
+    icon: str
+    # From LatestPrice
+    high: int | None = None
+    high_time: int | None = None
+    low: int | None = None
+    low_time: int | None = None
+
+
+class EnrichedLatestResponse(OSRSBaseModel):
+    """Response containing latest prices enriched with item metadata."""
+
+    items: list[EnrichedLatestPrice]
+
+
+class EnrichedAveragePrice(OSRSBaseModel):
+    """Average price combined with item metadata."""
+
+    # From ItemMapping
+    id: int
+    name: str
+    examine: str | None = None
+    members: bool
+    lowalch: int | None = None
+    highalch: int | None = None
+    limit: int | None = None
+    value: int | None = None
+    icon: str
+    # From AveragePrice
+    avg_high_price: int | None = None
+    high_price_volume: int | None = None
+    avg_low_price: int | None = None
+    low_price_volume: int | None = None
+
+
+class EnrichedAverageResponse(OSRSBaseModel):
+    """Response containing average prices enriched with item metadata."""
+
+    items: list[EnrichedAveragePrice]
+    timestamp: int
+
+
+class EnrichedTimeseriesResponse(OSRSBaseModel):
+    """Timeseries response with item metadata attached."""
+
+    item: ItemMapping
+    data: list[TimeseriesDataPoint]

--- a/src/osrs_prices/models/enriched.py
+++ b/src/osrs_prices/models/enriched.py
@@ -5,10 +5,9 @@ from osrs_prices.models.items import ItemMapping
 from osrs_prices.models.timeseries import TimeseriesDataPoint
 
 
-class EnrichedLatestPrice(OSRSBaseModel):
-    """Latest price combined with item metadata."""
+class EnrichedItemBase(OSRSBaseModel):
+    """Base class with common item metadata fields."""
 
-    # From ItemMapping
     id: int
     name: str
     examine: str | None = None
@@ -18,7 +17,11 @@ class EnrichedLatestPrice(OSRSBaseModel):
     limit: int | None = None
     value: int | None = None
     icon: str
-    # From LatestPrice
+
+
+class EnrichedLatestPrice(EnrichedItemBase):
+    """Latest price combined with item metadata."""
+
     high: int | None = None
     high_time: int | None = None
     low: int | None = None
@@ -31,20 +34,9 @@ class EnrichedLatestResponse(OSRSBaseModel):
     items: list[EnrichedLatestPrice]
 
 
-class EnrichedAveragePrice(OSRSBaseModel):
+class EnrichedAveragePrice(EnrichedItemBase):
     """Average price combined with item metadata."""
 
-    # From ItemMapping
-    id: int
-    name: str
-    examine: str | None = None
-    members: bool
-    lowalch: int | None = None
-    highalch: int | None = None
-    limit: int | None = None
-    value: int | None = None
-    icon: str
-    # From AveragePrice
     avg_high_price: int | None = None
     high_price_volume: int | None = None
     avg_low_price: int | None = None

--- a/src/osrs_prices/models/timeseries.py
+++ b/src/osrs_prices/models/timeseries.py
@@ -22,15 +22,22 @@ class TimeseriesDataPoint(OSRSBaseModel):
 class TimeseriesResponse(OSRSBaseModel):
     """Response from the /timeseries endpoint."""
 
+    item_id: int | None = None
     data: list[TimeseriesDataPoint] = Field(default_factory=list)
 
     @classmethod
-    def from_api(cls, data: dict[str, Any]) -> "TimeseriesResponse":
+    def from_api(
+        cls, data: dict[str, Any], item_id: int | None = None
+    ) -> "TimeseriesResponse":
         """Create a TimeseriesResponse from API data.
 
         The API returns {"data": [{...}, ...]}.
+
+        Args:
+            data: The raw API response data.
+            item_id: The item ID this timeseries is for.
         """
         points = [
             TimeseriesDataPoint.model_validate(point) for point in data.get("data", [])
         ]
-        return cls(data=points)
+        return cls(item_id=item_id, data=points)

--- a/tests/unit/test_enriched.py
+++ b/tests/unit/test_enriched.py
@@ -1,0 +1,394 @@
+"""Unit tests for enriched models and client methods."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from osrs_prices import (
+    Client,
+    EnrichedAveragePrice,
+    EnrichedAverageResponse,
+    EnrichedLatestPrice,
+    EnrichedLatestResponse,
+    EnrichedTimeseriesResponse,
+    ValidationError,
+)
+
+
+class TestEnrichedModels:
+    """Tests for enriched model construction."""
+
+    def test_enriched_latest_price_construction(self) -> None:
+        """Test EnrichedLatestPrice can be constructed with all fields."""
+        price = EnrichedLatestPrice(
+            id=4151,
+            name="Abyssal whip",
+            examine="A weapon from the abyss.",
+            members=True,
+            lowalch=28800,
+            highalch=43200,
+            limit=70,
+            value=72000,
+            icon="Abyssal_whip.png",
+            high=1500000,
+            high_time=1704067200,
+            low=1480000,
+            low_time=1704067180,
+        )
+
+        assert price.id == 4151
+        assert price.name == "Abyssal whip"
+        assert price.high == 1500000
+        assert price.limit == 70
+
+    def test_enriched_latest_price_optional_fields(self) -> None:
+        """Test EnrichedLatestPrice with optional fields as None."""
+        price = EnrichedLatestPrice(
+            id=4151,
+            name="Abyssal whip",
+            members=True,
+            icon="Abyssal_whip.png",
+        )
+
+        assert price.examine is None
+        assert price.high is None
+        assert price.low is None
+
+    def test_enriched_latest_response(self) -> None:
+        """Test EnrichedLatestResponse construction."""
+        items = [
+            EnrichedLatestPrice(
+                id=4151,
+                name="Abyssal whip",
+                members=True,
+                icon="Abyssal_whip.png",
+                high=1500000,
+            ),
+            EnrichedLatestPrice(
+                id=2,
+                name="Cannonball",
+                members=True,
+                icon="Cannonball.png",
+                high=150,
+            ),
+        ]
+        response = EnrichedLatestResponse(items=items)
+
+        assert len(response.items) == 2
+        assert response.items[0].name == "Abyssal whip"
+
+    def test_enriched_average_price_construction(self) -> None:
+        """Test EnrichedAveragePrice can be constructed with all fields."""
+        price = EnrichedAveragePrice(
+            id=4151,
+            name="Abyssal whip",
+            members=True,
+            icon="Abyssal_whip.png",
+            avg_high_price=1495000,
+            high_price_volume=50,
+            avg_low_price=1485000,
+            low_price_volume=45,
+        )
+
+        assert price.id == 4151
+        assert price.avg_high_price == 1495000
+        assert price.high_price_volume == 50
+
+    def test_enriched_average_response(self) -> None:
+        """Test EnrichedAverageResponse construction."""
+        items = [
+            EnrichedAveragePrice(
+                id=4151,
+                name="Abyssal whip",
+                members=True,
+                icon="Abyssal_whip.png",
+            ),
+        ]
+        response = EnrichedAverageResponse(items=items, timestamp=1704067200)
+
+        assert len(response.items) == 1
+        assert response.timestamp == 1704067200
+
+
+class TestClientEnrichedMethods:
+    """Tests for client enriched methods with mocked HTTP."""
+
+    @pytest.fixture
+    def mock_client(self) -> Client:
+        """Create a client with mocked HTTP."""
+        return Client(user_agent="test/1.0")
+
+    def test_get_latest_with_mapping(
+        self,
+        mock_client: Client,
+        sample_latest_response: dict,
+        sample_mapping_response: list[dict],
+    ) -> None:
+        """Test get_latest_with_mapping method."""
+        mock_latest_resp = MagicMock()
+        mock_latest_resp.status_code = 200
+        mock_latest_resp.json.return_value = sample_latest_response
+
+        mock_mapping_resp = MagicMock()
+        mock_mapping_resp.status_code = 200
+        mock_mapping_resp.json.return_value = sample_mapping_response
+
+        def mock_get(url: str, **kwargs) -> MagicMock:
+            if "/mapping" in url:
+                return mock_mapping_resp
+            return mock_latest_resp
+
+        with patch.object(mock_client._http_client, "get", side_effect=mock_get):
+            result = mock_client.get_latest_with_mapping()
+
+            assert isinstance(result, EnrichedLatestResponse)
+            assert len(result.items) == 2
+
+            whip = next((item for item in result.items if item.id == 4151), None)
+            assert whip is not None
+            assert whip.name == "Abyssal whip"
+            assert whip.high == 1500000
+            assert whip.limit == 70
+
+        mock_client.close()
+
+    def test_get_latest_with_mapping_single_item(
+        self,
+        mock_client: Client,
+        sample_latest_single_item_response: dict,
+        sample_mapping_response: list[dict],
+    ) -> None:
+        """Test get_latest_with_mapping with specific item_id."""
+        mock_latest_resp = MagicMock()
+        mock_latest_resp.status_code = 200
+        mock_latest_resp.json.return_value = sample_latest_single_item_response
+
+        mock_mapping_resp = MagicMock()
+        mock_mapping_resp.status_code = 200
+        mock_mapping_resp.json.return_value = sample_mapping_response
+
+        def mock_get(url: str, **kwargs) -> MagicMock:
+            if "/mapping" in url:
+                return mock_mapping_resp
+            return mock_latest_resp
+
+        with patch.object(mock_client._http_client, "get", side_effect=mock_get):
+            result = mock_client.get_latest_with_mapping(item_id=4151)
+
+            assert len(result.items) == 1
+            assert result.items[0].id == 4151
+            assert result.items[0].name == "Abyssal whip"
+
+        mock_client.close()
+
+    def test_get_5m_average_with_mapping(
+        self,
+        mock_client: Client,
+        sample_5m_response: dict,
+        sample_mapping_response: list[dict],
+    ) -> None:
+        """Test get_5m_average_with_mapping method."""
+        mock_avg_resp = MagicMock()
+        mock_avg_resp.status_code = 200
+        mock_avg_resp.json.return_value = sample_5m_response
+
+        mock_mapping_resp = MagicMock()
+        mock_mapping_resp.status_code = 200
+        mock_mapping_resp.json.return_value = sample_mapping_response
+
+        def mock_get(url: str, **kwargs) -> MagicMock:
+            if "/mapping" in url:
+                return mock_mapping_resp
+            return mock_avg_resp
+
+        with patch.object(mock_client._http_client, "get", side_effect=mock_get):
+            result = mock_client.get_5m_average_with_mapping()
+
+            assert isinstance(result, EnrichedAverageResponse)
+            assert result.timestamp == 1704067200
+            assert len(result.items) == 2
+
+            whip = next((item for item in result.items if item.id == 4151), None)
+            assert whip is not None
+            assert whip.name == "Abyssal whip"
+            assert whip.avg_high_price == 1495000
+
+        mock_client.close()
+
+    def test_get_1h_average_with_mapping(
+        self,
+        mock_client: Client,
+        sample_1h_response: dict,
+        sample_mapping_response: list[dict],
+    ) -> None:
+        """Test get_1h_average_with_mapping method."""
+        mock_avg_resp = MagicMock()
+        mock_avg_resp.status_code = 200
+        mock_avg_resp.json.return_value = sample_1h_response
+
+        mock_mapping_resp = MagicMock()
+        mock_mapping_resp.status_code = 200
+        mock_mapping_resp.json.return_value = sample_mapping_response
+
+        def mock_get(url: str, **kwargs) -> MagicMock:
+            if "/mapping" in url:
+                return mock_mapping_resp
+            return mock_avg_resp
+
+        with patch.object(mock_client._http_client, "get", side_effect=mock_get):
+            result = mock_client.get_1h_average_with_mapping()
+
+            assert isinstance(result, EnrichedAverageResponse)
+            assert result.timestamp == 1704067200
+            assert len(result.items) == 1
+
+        mock_client.close()
+
+    def test_get_timeseries_with_mapping(
+        self,
+        mock_client: Client,
+        sample_timeseries_response: dict,
+        sample_mapping_response: list[dict],
+    ) -> None:
+        """Test get_timeseries_with_mapping method."""
+        mock_ts_resp = MagicMock()
+        mock_ts_resp.status_code = 200
+        mock_ts_resp.json.return_value = sample_timeseries_response
+
+        mock_mapping_resp = MagicMock()
+        mock_mapping_resp.status_code = 200
+        mock_mapping_resp.json.return_value = sample_mapping_response
+
+        def mock_get(url: str, **kwargs) -> MagicMock:
+            if "/mapping" in url:
+                return mock_mapping_resp
+            return mock_ts_resp
+
+        with patch.object(mock_client._http_client, "get", side_effect=mock_get):
+            result = mock_client.get_timeseries_with_mapping(item_id=4151, timestep="1h")
+
+            assert isinstance(result, EnrichedTimeseriesResponse)
+            assert result.item.id == 4151
+            assert result.item.name == "Abyssal whip"
+            assert len(result.data) == 3
+
+        mock_client.close()
+
+    def test_get_timeseries_with_mapping_unknown_item(
+        self,
+        mock_client: Client,
+        sample_timeseries_response: dict,
+        sample_mapping_response: list[dict],
+    ) -> None:
+        """Test get_timeseries_with_mapping raises for unknown item."""
+        mock_ts_resp = MagicMock()
+        mock_ts_resp.status_code = 200
+        mock_ts_resp.json.return_value = sample_timeseries_response
+
+        mock_mapping_resp = MagicMock()
+        mock_mapping_resp.status_code = 200
+        mock_mapping_resp.json.return_value = sample_mapping_response
+
+        def mock_get(url: str, **kwargs) -> MagicMock:
+            if "/mapping" in url:
+                return mock_mapping_resp
+            return mock_ts_resp
+
+        with patch.object(mock_client._http_client, "get", side_effect=mock_get):
+            with pytest.raises(ValidationError, match="not found in mapping"):
+                mock_client.get_timeseries_with_mapping(item_id=99999, timestep="1h")
+
+        mock_client.close()
+
+    def test_enrich_latest_response(
+        self,
+        mock_client: Client,
+        sample_latest_response: dict,
+        sample_mapping_response: list[dict],
+    ) -> None:
+        """Test enrich method with LatestResponse."""
+        mock_latest_resp = MagicMock()
+        mock_latest_resp.status_code = 200
+        mock_latest_resp.json.return_value = sample_latest_response
+
+        mock_mapping_resp = MagicMock()
+        mock_mapping_resp.status_code = 200
+        mock_mapping_resp.json.return_value = sample_mapping_response
+
+        def mock_get(url: str, **kwargs) -> MagicMock:
+            if "/mapping" in url:
+                return mock_mapping_resp
+            return mock_latest_resp
+
+        with patch.object(mock_client._http_client, "get", side_effect=mock_get):
+            latest = mock_client.get_latest()
+            enriched = mock_client.enrich(latest)
+
+            assert isinstance(enriched, EnrichedLatestResponse)
+            assert len(enriched.items) == 2
+
+        mock_client.close()
+
+    def test_enrich_average_response(
+        self,
+        mock_client: Client,
+        sample_5m_response: dict,
+        sample_mapping_response: list[dict],
+    ) -> None:
+        """Test enrich method with AverageResponse."""
+        mock_avg_resp = MagicMock()
+        mock_avg_resp.status_code = 200
+        mock_avg_resp.json.return_value = sample_5m_response
+
+        mock_mapping_resp = MagicMock()
+        mock_mapping_resp.status_code = 200
+        mock_mapping_resp.json.return_value = sample_mapping_response
+
+        def mock_get(url: str, **kwargs) -> MagicMock:
+            if "/mapping" in url:
+                return mock_mapping_resp
+            return mock_avg_resp
+
+        with patch.object(mock_client._http_client, "get", side_effect=mock_get):
+            averages = mock_client.get_5m_average()
+            enriched = mock_client.enrich(averages)
+
+            assert isinstance(enriched, EnrichedAverageResponse)
+            assert enriched.timestamp == 1704067200
+            assert len(enriched.items) == 2
+
+        mock_client.close()
+
+    def test_enriched_methods_use_cached_mapping(
+        self,
+        mock_client: Client,
+        sample_latest_response: dict,
+        sample_mapping_response: list[dict],
+    ) -> None:
+        """Test that enriched methods use cached mapping data."""
+        mock_latest_resp = MagicMock()
+        mock_latest_resp.status_code = 200
+        mock_latest_resp.json.return_value = sample_latest_response
+
+        mock_mapping_resp = MagicMock()
+        mock_mapping_resp.status_code = 200
+        mock_mapping_resp.json.return_value = sample_mapping_response
+
+        mapping_calls = []
+
+        def mock_get(url: str, **kwargs) -> MagicMock:
+            if "/mapping" in url:
+                mapping_calls.append(url)
+                return mock_mapping_resp
+            return mock_latest_resp
+
+        with patch.object(mock_client._http_client, "get", side_effect=mock_get):
+            # First call should hit mapping API
+            mock_client.get_latest_with_mapping()
+            assert len(mapping_calls) == 1
+
+            # Second call should use cache
+            mock_client.get_latest_with_mapping()
+            assert len(mapping_calls) == 1
+
+        mock_client.close()


### PR DESCRIPTION
## Summary

- Add new `get_*_with_mapping()` methods that return price data combined with item metadata (name, examine, alch values, limits, etc.)
- Add `client.enrich()` helper to enrich existing responses
- Add new enriched model types for type-safe access to combined data

## New Client Methods

| Method | Description |
|--------|-------------|
| `get_latest_with_mapping(item_id=None)` | Latest prices with item metadata |
| `get_5m_average_with_mapping(timestamp=None)` | 5-minute averages with item metadata |
| `get_1h_average_with_mapping(timestamp=None)` | 1-hour averages with item metadata |
| `get_timeseries_with_mapping(item_id, timestep)` | Timeseries with item metadata |
| `enrich(response)` | Add item metadata to an existing response |

## New Models

- `EnrichedLatestPrice` - Latest price combined with item metadata
- `EnrichedLatestResponse` - Response containing enriched latest prices
- `EnrichedAveragePrice` - Average price combined with item metadata
- `EnrichedAverageResponse` - Response containing enriched average prices
- `EnrichedTimeseriesResponse` - Timeseries with item metadata attached

## Usage Example

```python
from osrs_prices import Client

with Client(user_agent="my-app/1.0") as client:
    # Get prices with item names, limits, alch values, etc.
    enriched = client.get_latest_with_mapping()
    for item in enriched.items:
        print(f"{item.name}: {item.high} gp (limit: {item.limit})")

    # Or enrich an existing response
    latest = client.get_latest()
    enriched = client.enrich(latest)
```

## Test plan

- [x] Unit tests for all new models
- [x] Unit tests for all new client methods
- [x] Type checking passes (`uv run mypy src/`)
- [x] All tests pass (`uv run pytest tests/unit`)
- [x] Documentation builds (`uv run mkdocs build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)