### PR TITLE
ci: use PAT for release-please to trigger workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   publish:
     needs: release-please


### PR DESCRIPTION
## Summary

- Use `RELEASE_PLEASE_TOKEN` (PAT) instead of default `GITHUB_TOKEN` for release-please

The default `GITHUB_TOKEN` cannot trigger other workflows due to GitHub's security restrictions. This causes CI checks to show "Waiting for status to be reported" on release-please PRs.

Using a PAT allows the CI, Commit Lint, and Docs workflows to run when release-please creates or updates PRs.

## Test plan

- [x] Added `RELEASE_PLEASE_TOKEN` secret to repository
- [ ] Merge this PR and verify next release-please PR has checks running

🤖 Generated with [Claude Code](https://claude.com/claude-code)